### PR TITLE
Python 3.8 compatibility fix.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -991,7 +991,7 @@ class ExportAse( bpy.types.Operator, ExportHelper ):
             file.close()
 
     def execute( self, context ):
-        start = time.clock()
+        start = time.process_time()
 
         global optionScale
         global optionSubmaterials
@@ -1070,7 +1070,7 @@ class ExportAse( bpy.types.Operator, ExportHelper ):
         # Write the ASE file
         self.writeASE( self.filepath, aseModel )
 
-        lapse = ( time.clock() - start )
+        lapse = ( time.process_time() - start )
         print( 'Completed in ' + str( lapse ) + ' seconds' )
 
         return {'FINISHED'}


### PR DESCRIPTION
The function time.clock() has been removed, after having been deprecated since Python 3.3: use time.perf_counter() or time.process_time() instead, depending on your requirements, to have well-defined behavior. https://docs.python.org/3/whatsnew/3.8.html