### PR TITLE
Fix time attribute

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -991,7 +991,7 @@ class ExportAse( bpy.types.Operator, ExportHelper ):
             file.close()
 
     def execute( self, context ):
-        start = time.clock()
+        start = time.time()
 
         global optionScale
         global optionSubmaterials
@@ -1070,7 +1070,7 @@ class ExportAse( bpy.types.Operator, ExportHelper ):
         # Write the ASE file
         self.writeASE( self.filepath, aseModel )
 
-        lapse = ( time.clock() - start )
+        lapse = ( time.time() - start )
         print( 'Completed in ' + str( lapse ) + ' seconds' )
 
         return {'FINISHED'}


### PR DESCRIPTION
Resolved the *.ase export error that resulted in AttributeError: module 'time' has no attribute 'clock'. Tested in Blender 2.93 LTS release.